### PR TITLE
Add support for two optional mol_to_smiles keyword arguments

### DIFF
--- a/src/io/write.jl
+++ b/src/io/write.jl
@@ -3,13 +3,15 @@
 #######################################################
 
 """
-    mol_to_smiles(mol::Union{Molecule,Missing}) -> Union{String,Missing}
+    mol_to_smiles(mol::Union{Molecule,Missing}; kekule_smiles::Bool = false, all_bonds_explicit::Bool = false) -> Union{String,Missing}
 
 Convert a Molecule object to a SMILES string.
 
 # Arguments
 
   - `mol::Union{Molecule,Missing}`: A Molecule object or missing
+  - `kekule_smiles::Bool`: (optional) use the Kekule form (no aromatic bonds) in the SMILES. Defaults to false
+  - `all_bonds_explicit::Bool`: (optional) if true, all bond orders will be explicitly indicated in the output SMILES. Defaults to false
 
 # Returns
 
@@ -23,30 +25,60 @@ smiles = mol_to_smiles(mol)  # "CCO"
 
 # Handles missing values gracefully
 smiles = mol_to_smiles(missing)  # missing
+
+benzene = mol_from_smiles("c1ccccc1")
+smiles = mol_to_smiles(benzene; kekule_smiles = true, all_bonds_explicit = true) # "C1=C-C=C-C=C-1"
 ```
 """
-function mol_to_smiles(mol::Union{Molecule, Missing})
+function mol_to_smiles(
+    mol::Union{Molecule, Missing};
+    kekule_smiles::Bool = false,
+    all_bonds_explicit::Bool = false,
+)
     isa(mol, Missing) && return missing
     !mol.valid && return missing
-    return pyconvert(String, _mol_to_smiles(mol._rdkit_mol))
+    return pyconvert(
+        String,
+        _mol_to_smiles(
+            mol._rdkit_mol;
+            kekuleSmiles = kekule_smiles,
+            allBondsExplicit = all_bonds_explicit,
+        ),
+    )
 end
 
-function mol_to_smiles(mol_list::Vector{Union{Molecule, Missing}})
+function mol_to_smiles(
+    mol_list::Vector{Union{Molecule, Missing}};
+    kekule_smiles::Bool = false,
+    all_bonds_explicit::Bool = false,
+)
     results = Vector{Union{String, Missing}}(undef, length(mol_list))
 
     @inbounds for i in eachindex(mol_list)
-        smiles = mol_to_smiles(mol_list[i])
+        smiles = mol_to_smiles(
+            mol_list[i];
+            kekule_smiles = kekule_smiles,
+            all_bonds_explicit = all_bonds_explicit,
+        )
         results[i] = smiles
     end
 
     return pyconvert(Vector{Union{String, Missing}}, results)
 end
 
-function mol_to_smiles(mol_list::Vector{Molecule})
+function mol_to_smiles(
+    mol_list::Vector{Molecule};
+    kekule_smiles::Bool = false,
+    all_bonds_explicit::Bool = false,
+)
     results = Vector{Union{String, Missing}}(undef, length(mol_list))
 
     @inbounds for i in eachindex(mol_list)
-        smiles = mol_to_smiles(mol_list[i])
+        smiles = mol_to_smiles(
+            mol_list[i];
+            kekule_smiles = kekule_smiles,
+            all_bonds_explicit = all_bonds_explicit,
+        )
         results[i] = smiles
     end
 

--- a/src/rdkit.jl
+++ b/src/rdkit.jl
@@ -12,7 +12,10 @@ end
 function _sdf_supplier(filename::String)
     @pyconst(pyimport("rdkit.Chem").SDMolSupplier)(filename)
 end
-_mol_to_smiles(mol::Py) = @pyconst(pyimport("rdkit.Chem").MolToSmiles)(mol)
+_mol_to_smiles(mol::Py; kekuleSmiles::Bool = false, allBondsExplicit::Bool = false) =
+    @pyconst(pyimport("rdkit.Chem").MolToSmiles)(
+        mol; kekuleSmiles = kekuleSmiles, allBondsExplicit = allBondsExplicit
+    )
 _mol_to_inchi(mol::Py) = @pyconst(pyimport("rdkit.Chem").MolToInchi)(mol)
 _mol_from_smarts(smarts::String) = @pyconst(pyimport("rdkit.Chem").MolFromSmarts)(smarts)
 _mol_copy(mol::Py) = @pyconst(pyimport("rdkit.Chem").Mol)(mol)
@@ -356,8 +359,8 @@ end
 function _split_mol_by_pdb_residues(mol::Py)
     @pyconst(pyimport("rdkit.Chem").SplitMolByPDBResidues)(mol)
 end
-function _kekulize(mol::Py; clearAromaticFlags::Bool=false)
-    @pyconst(pyimport("rdkit.Chem").Kekulize)(mol; clearAromaticFlags=clearAromaticFlags)
+function _kekulize(mol::Py; clearAromaticFlags::Bool = false)
+    @pyconst(pyimport("rdkit.Chem").Kekulize)(mol; clearAromaticFlags = clearAromaticFlags)
 end
 
 # Stereochemistry and 3D operations
@@ -419,7 +422,9 @@ end
 
 # Fragmentation
 function _brics_decompose(mol::Py; minFragmentSize::Int)
-    @pyconst(pyimport("rdkit.Chem.BRICS").BRICSDecompose)(mol; minFragmentSize = minFragmentSize)
+    @pyconst(pyimport("rdkit.Chem.BRICS").BRICSDecompose)(
+        mol; minFragmentSize = minFragmentSize
+    )
 end
 function _recap_decompose(mol::Py)
     @pyconst(pyimport("rdkit.Chem.Recap").RecapDecompose)(mol)

--- a/test/test_molecules.jl
+++ b/test/test_molecules.jl
@@ -16,6 +16,15 @@ using MoleculeFlow
     @test isa(smiles, String)
     @test length(smiles) > 0
 
+    # Test kekule_smiles
+    benzene = mol_from_smiles("c1ccccc1")
+    @test mol_to_smiles(benzene; kekule_smiles = true) == "C1=CC=CC=C1"
+    @test mol_to_smiles(benzene; kekule_smiles = false) == "c1ccccc1"
+
+    # Test all_bonds_explicit
+    @test mol_to_smiles(benzene; kekule_smiles = true, all_bonds_explicit = true) ==
+        "C1=C-C=C-C=C-1"
+
     # Test InChI conversion  
     inchi = mol_to_inchi(mol)
     @test isa(inchi, String)


### PR DESCRIPTION
Added support for optional kekule_smiles and all_bonds_explicit keyword arguments for [mol_to_smiles function](https://www.rdkit.org/docs/source/rdkit.Chem.rdmolfiles.html#rdkit.Chem.rdmolfiles.MolToSmiles)